### PR TITLE
Added httpClear method to Sodaq_R4X.h

### DIFF
--- a/src/Sodaq_R4X.h
+++ b/src/Sodaq_R4X.h
@@ -342,6 +342,7 @@ public:
     //  Parameters 'name' and 'value' must not include the ':' character
     bool httpSetCustomHeader(uint8_t index, const char* name, const char* value);
     bool httpClearCustomHeader(uint8_t index);
+    bool httpClear();
 
 
     /******************************************************************************


### PR DESCRIPTION
I have removed the AT+UHTTP=0 from methods httpRequestFromFile and httpRequest as suggested by Ingvars (https://forum.sodaq.com/t/set-headers-sara-r410/3138/4) To replace this function I've added a new method to do clearing of the HTTP profile on request