### PR TITLE
Update Sodaq_R4X.cpp to add httpClear method and removed AT+UHTTP=0 blocks

### DIFF
--- a/src/Sodaq_R4X.cpp
+++ b/src/Sodaq_R4X.cpp
@@ -1633,12 +1633,6 @@ size_t Sodaq_R4X::httpRequest(const char* server, uint16_t port, const char* end
                                    HTTP_SEND_TMP_FILENAME, timeout, useURC);
     }
 
-    // reset http profile 0
-    println("AT+UHTTP=0");
-    if (readResponse() != GSMResponseOK) {
-        return 0;
-    }
-
     deleteFile(HTTP_RECEIVE_FILENAME); // cleanup the file first (if exists)
 
     if (requestType >= HttpRequestTypesMAX) {
@@ -1740,12 +1734,6 @@ size_t Sodaq_R4X::httpRequestFromFile(const char* server, uint16_t port, const c
                                       const char* fileName, uint32_t timeout, bool useURC)
 {
     if (requestType != PUT && requestType != POST) {
-        return 0;
-    }
-
-    // reset http profile 0
-    println("AT+UHTTP=0");
-    if (readResponse() != GSMResponseOK) {
         return 0;
     }
 
@@ -1861,6 +1849,13 @@ bool Sodaq_R4X::httpSetCustomHeader(uint8_t index, const char* name, const char*
 
     println('"');
 
+    return (readResponse() == GSMResponseOK);
+}
+
+bool Sodaq_R4X::httpClear()
+{
+
+    println("AT+UHTTP=0");
     return (readResponse() == GSMResponseOK);
 }
 

--- a/src/Sodaq_R4X.cpp
+++ b/src/Sodaq_R4X.cpp
@@ -2050,7 +2050,7 @@ bool Sodaq_R4X::writeFile(const char* filename, const uint8_t* buffer, size_t si
         return false;
     }
 
-    for (size_t i = 0; i < size; i++) {
+    for (size_t i = 0; i < size-1; i++) {
         writeByte(buffer[i]);
     }
 


### PR DESCRIPTION
I have removed the AT+UHTTP=0 from methods httpRequestFromFile and httpRequest as suggested by Ingvars (https://forum.sodaq.com/t/set-headers-sara-r410/3138/4) To replace this function I've added a new method to do clearing of the HTTP profile on request