### PR TITLE
Add MNO profile standard Europe No-ePCO (101)

### DIFF
--- a/src/Sodaq_R4X.h
+++ b/src/Sodaq_R4X.h
@@ -90,6 +90,7 @@ enum HttpRequestTypes {
  * • 32: US Cellular
  * • 39: SKT
  * • 100: standard Europe
+ * • 101: standard Europe, without ePCO
  */
 enum MNOProfile {
     SWD_DEFAULT     = 0,
@@ -107,6 +108,7 @@ enum MNOProfile {
     US_CELLULAR     = 32,
     SKT             = 39,
     STANDARD_EUROPE = 100,
+    STANDARD_EUROPE_NOEPCO = 101,
 };
 
 enum SimStatuses {


### PR DESCRIPTION
Using standard europe profile (100) leads into no DNS assigned to a SARA-R410M-02B, with an emnify sim, when using NB-IOT.

With profile 101, standard Europe No-ePCO, works as expected.